### PR TITLE
feat: update AI model to `openai/gpt-4o-mini` and set token limit

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -50,7 +50,8 @@ jobs:
             - **Key Information:** [Your extracted key information]
             - **User Expectation:** [Your extracted user expectation or N/A]
             - **Reproducibility:** [Yes|No|Partial|N/A]
-          model: openai/gpt-4.1
+          model: openai/gpt-4o-mini
+          max-tokens: 800
 
       - name: Post AI Analysis as Comment
         env:


### PR DESCRIPTION
- Change model from `openai/gpt-4.1` to `openai/gpt-4o-mini` for enhanced performance
- Add `max-tokens` parameter with a limit of 800